### PR TITLE
feat: reset state on stop when meta tag is removed

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -93,6 +93,10 @@ export class GlobalWebMonetizationState extends EventEmitter {
   }
 
   onMonetizationStop() {
+    if (!document.head.querySelector('meta[name="monetization"]')) {
+      this.resetState()
+    }
+
     this.setStateFromDocumentMonetization()
     this.emit('monetizationstop')
   }


### PR DESCRIPTION
prevents hasPaid from unintentionally sticking around too long after meta tag is removed.