### PR TITLE
fix: reset when meta tag changes on stopped state

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -93,7 +93,8 @@ export class GlobalWebMonetizationState extends EventEmitter {
   }
 
   onMonetizationStop() {
-    if (!document.head.querySelector('meta[name="monetization"]')) {
+    const metaTag = document.head.querySelector('meta[name="monetization"]')
+    if (!metaTag || metaTag.content !== this.paymentPointer) {
       this.resetState()
     }
 


### PR DESCRIPTION
Should stop errors where hasPaid lingered even though meta tag payment pointer was changed.